### PR TITLE
Add SerialCarouselBuilder to dev-main

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install
         run: |
-          pip install -e .[testing]
+          pip install -e ./[testing]
 
       - name: Test
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install
         run: |
-          pip install -e ./[testing]
+          pip install -e .[testing]
 
       - name: Test
         run: |

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -371,7 +371,7 @@ class CarouselBuilder(Structure):
                     flow_sheet.add_connection(col.bottom, zone.outlet_unit)
         
         # Connect each bottom of each column to the top of next
-        self._add_ring_connections(self, flow_sheet)
+        self._add_ring_connections(flow_sheet)
 
 
 

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -24,6 +24,7 @@ __all__ = [
     "SerialZone",
     "ParallelZone",
     "CarouselBuilder",
+    "SerialCarouselBuilder",
     "SMBBuilder",
     "LinearSMBBuilder",
     "LangmuirSMBBuilder",

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -660,30 +660,6 @@ class SerialCarouselBuilder(CarouselBuilder):
                         process.add_event_dependency(
                             evt.name, "switch_time", [carousel_state]
                             )
-                    
-                    # evt = process.add_event(
-                    #     f"{zone.name}_{carousel_state}",
-                    #     f"flow_sheet.output_states.{zone.inlet_unit}",
-                    #     cols[0].index
-                    # )
-                    # process.add_event_dependency(
-                    #     evt.name, "switch_time", [carousel_state]
-                    # )
-
-                    # # Current column either feeds next column or goes
-                    # # to outlet
-                    # for seq_i, col in enumerate(cols):
-                    #     dest = (self.n_zones
-                    #             if seq_i < zone.n_columns - 1
-                    #             else i_zone)
-                    #     evt = process.add_event(
-                    #         f"column_{col.index}_{carousel_state}",
-                    #         f"flow_sheet.output_states.{col.bottom.name}",
-                    #         dest
-                    #     )
-                    #     process.add_event_dependency(
-                    #         evt.name, "switch_time", [carousel_state]
-                    #     )
 
                 elif isinstance(zone, ParallelZone):
                     raise TypeError('SerialCarouselBuilder only supports SerialZones.')

--- a/tests/test_carousel.py
+++ b/tests/test_carousel.py
@@ -800,7 +800,7 @@ class Test_SerialCarousel(unittest.TestCase):
 
     def test_simulate(self):
         builder, _ = self.create_carousel(with_pipe=False)
-        process = builder.build_process
+        process = builder.build_process()
         process_simulator = Cadet()
         simulation_results = process_simulator.simulate(process)
 


### PR DESCRIPTION
PR adds the SerialCarouselBuilder class which expands on the functionality of the CarouselBuilder.
SerialCarouselBuilder is a specific constructor to create SMBs with columns within each zone always connected in series with an optional pipe connecting the bottom of one column to the top of the next to better model volumes in real carousel-style SMB systems.
- Optional pipe is added similar to how the column unit(s) is passed to the constructor class and can be defined as any unit operation model
- Constructor class handles creating the ring connections; if no pipe is passed, the bottom of each column is connected to the top of the next column (same as CarouselBuilder); if a pipe is passed, the bottom of each column is connected to the pipe and the pipe to the top of the next column

A method has also been added to CarouselBuilder to handle the ring connection logic, this method is overridden in the SerialCarouselBuilder to minimize code duplication. 